### PR TITLE
Remove snakecase from function name

### DIFF
--- a/src-cljs/parser.cljs
+++ b/src-cljs/parser.cljs
@@ -5,7 +5,7 @@
   )
 
 
-(defn cat_two_first[array]
+(defn cat-two-first[array]
   (conj (rest (rest array)) (clojure.string/join [(first array) (second array)] ))
 )
 
@@ -26,7 +26,7 @@
   (let [first-char (str (first (first array)))]
 
    (if (skippable-char? first-char)
-    (cat_two_first array)
+    (cat-two-first array)
     array
     )
   )


### PR DESCRIPTION
There is no reason to use underscores in `cat_two_first` 
