### PR TITLE
Escape HTML, and fix spaces.

### DIFF
--- a/resources/public/script.js
+++ b/resources/public/script.js
@@ -100,6 +100,13 @@ function createExpression(locations){
   return "[" + editor.getValue() + "]"
 }
 
+var escapeEl = document.createElement('textarea');
+
+function escapeHTML(html) {
+  escapeEl.textContent = html;
+  return escapeEl.innerHTML;
+}
+
 function compile() {
     var code = editor.getValue()
     var locations = parser.get_print_locations(code)
@@ -127,7 +134,7 @@ function compile() {
             results.forEach(function(result, i) {
                 jQuery('<div/>', {
                     class: 'info',
-                    text: result,
+                    innerHTML: escapeHTML(result).replace(/ /g, "&nbsp;"),
                     row: locations[i][1]
                  })
                 .css('left', EDITOR_LEFT + (locations[i][0] + lineIndent) * FONT_HORIZONTAL_SIZE + 'px')


### PR DESCRIPTION
I fixed the issue of rendering spaces by substituting for `&nbsp;`. In addition I've made HTML strings render correctly.

![screen shot 2014-10-25 at 10 44 07 am](https://cloud.githubusercontent.com/assets/51608/4780567/94d4782c-5c6e-11e4-82ea-d36c082c07bd.png)

Re: http://www.longstorm.org/weekly/cito/2/
